### PR TITLE
Update to 0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: sqlparse
@@ -7,7 +7,7 @@ package:
 source:
   fn: sqlparse-{{ version }}.tar.gz
   url: https://github.com/andialbrecht/sqlparse/archive/{{ version }}.tar.gz
-  sha256: a1919e7895a66d285395a67e09f865610e06330e8a2d309ad76c09390d4c7b47
+  sha256: 33cec505e752a237efcc2466763d3aef5f2dcbe1af301f607a39fe7b427a1513
 
 build:
   number: 0


### PR DESCRIPTION
## Release 0.2.2 (Oct 22, 2016)

Enhancements
- Add comma_first option: When splitting list "comma first" notation
  is used (issue141).
### Bug Fixes
- Fix parsing of incomplete AS (issue284, by vmuriart).
- Fix parsing of Oracle names containing dollars (issue291).
- Fix parsing of UNION ALL (issue294).
- Fix grouping of identifiers containing typecasts (issue297).
- Add Changelog to sdist again (issue302).
### Internal Changes
- `is_whitespace` and `is_group` changed into properties
